### PR TITLE
pf_bb_config: fix segmentation fault in SysFS mode

### DIFF
--- a/config_app.c
+++ b/config_app.c
@@ -331,6 +331,10 @@ sysfs_get_bar0_mapping(const char *pci_addr, unsigned int bar_size)
 	map = mmap(0, bar_size, PROT_READ | PROT_WRITE, MAP_SHARED,
 			bar0addrfd, 0);
 	close(bar0addrfd);
+	if (map == MAP_FAILED) {
+		printf("ERR:SYSFS: mmap failed\n");
+		map = NULL; /* MAP_FAILED is not equal to NULL */
+	}
 	return map;
 }
 


### PR DESCRIPTION
In VFIO case, map is set to NULL when mmap failed, but
it is not done in case SYSFS is used, where MAP_FAILED
value (~0ULL) is kept.

The ~0UL value not being considered invalid later one, a
segmentation fault happens when trying to access the BAR:

Program received signal SIGSEGV, Segmentation fault.
0x000000000040286d in acc100_reg_read (mmio_base=0xffffffffffffffff <error: Cannot access memory at address 0xffffffffffffffff>, offset=14223368) at acc100/acc100_cfg_app.c:47
47		uint32_t ret = *((volatile uint32_t *)(reg_addr));
(gdb) bt
    offset=14223368) at acc100/acc100_cfg_app.c:47
    cfg_filename=0x7fffffffe411 "/usr/share/pf-bb-config/acc100/acc100_config_pf.cfg") at acc100/acc100_cfg_app.c:794
(gdb) f 2

For consistency with VFIO, this patch sets BAR0 address to
NULL when mmap via SysFS failed.

Signed-off-by: Maxime Coquelin <maxime.coquelin@redhat.com>