### PR TITLE
acc200: fix build on big-endian architectures

### DIFF
--- a/acc200/acc200_cfg_app.c
+++ b/acc200/acc200_cfg_app.c
@@ -8339,7 +8339,7 @@ acc200_reg_write(uint8_t *mmio_base, uint32_t offset, uint32_t payload)
 {
 	void *reg_addr = mmio_base + offset;
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	value = __bswap_32(payload);
+	payload = __bswap_32(payload);
 #endif
 	*((volatile uint32_t *) (reg_addr)) = payload;
 	usleep(1000);
@@ -8350,7 +8350,7 @@ acc200_reg_fast_write(uint8_t *mmio_base, uint32_t offset, uint32_t payload)
 {
 	void *reg_addr = mmio_base + offset;
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	value = __bswap_32(payload);
+	payload = __bswap_32(payload);
 #endif
 	*((volatile uint32_t *) (reg_addr)) = payload;
 }


### PR DESCRIPTION
The variable 'value' is not declared, so build fails on big-endian architectures. Let's just reuse 'payload.

acc200/acc200_cfg_app.c: In function 'acc200_reg_write': acc200/acc200_cfg_app.c:8342:9: error: 'value' undeclared (first use in this function)
 8342 |         value = __bswap_32(payload);
      |         ^~~~~
acc200/acc200_cfg_app.c:8342:9: note: each undeclared identifier is reported only once for each function it appears in
acc200/acc200_cfg_app.c: In function 'acc200_reg_fast_write':
acc200/acc200_cfg_app.c:8353:9: error: 'value' undeclared (first use in this function)
 8353 |         value = __bswap_32(payload);
      |         ^~~~~

Reported-by: Timothy Redaelli <tredaelli@redhat.com>
Signed-off-by: Maxime Coquelin <maxime.coquelin@redhat.com>